### PR TITLE
fix(parser): escape all single quotes in lines

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -67,7 +67,8 @@ function badYamlToObj(text: string) {
     const [key, val] = line.split(":");
 
     if (key.trim()) {
-      let cleanVal = val.trim().replace(`'`, `''`);
+      let cleanVal = val.trim().replace(/'/g, "''");
+
       if (cleanVal.trim() === "") {
         cleanVal = "";
       } else {
@@ -75,14 +76,14 @@ function badYamlToObj(text: string) {
       }
       cleaned = `${key}__${i}:${cleanVal}`;
     }
+
     normalizedYaml += `${cleaned}\n`;
     i++;
   }
 
-  let obj = yaml.parse(normalizedYaml);
-  obj = camelizeKeys(obj);
+  const obj = yaml.parse(normalizedYaml);
 
-  return obj;
+  return camelizeKeys(obj);
 }
 
 /**

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -117,4 +117,11 @@ describe("SEC EDGAR Parser", () => {
       publicDocumentCount: "2",
     });
   });
+
+  test("Properly parses document 7", async () => {
+    const obj = await parser.getObjectFromString(docs[7]);
+
+    expect(obj.filer[0].businessAddress.street1).toBe("26 SE'ADYA GA'ON");
+    expect(obj.filer[0].mailAddress.street1).toBe("26 SE'ADYA GA'ON");
+  });
 });

--- a/test/test-fixtures/7.txt
+++ b/test/test-fixtures/7.txt
@@ -1,0 +1,107 @@
+<SEC-DOCUMENT>0001178913-20-000417.txt : 20200213
+<SEC-HEADER>0001178913-20-000417.hdr.sgml : 20200213
+<ACCEPTANCE-DATETIME>20200213063735
+ACCESSION NUMBER:		0001178913-20-000417
+CONFORMED SUBMISSION TYPE:	13F-NT
+PUBLIC DOCUMENT COUNT:		1
+CONFORMED PERIOD OF REPORT:	20191231
+FILED AS OF DATE:		20200213
+DATE AS OF CHANGE:		20200213
+EFFECTIVENESS DATE:		20200213
+
+FILER:
+
+	COMPANY DATA:	
+		COMPANY CONFORMED NAME:			Migdal Investment Portfolio Management (1998) Ltd.
+		CENTRAL INDEX KEY:			0001727574
+		IRS NUMBER:				512718230
+
+	FILING VALUES:
+		FORM TYPE:		13F-NT
+		SEC ACT:		1934 Act
+		SEC FILE NUMBER:	028-18263
+		FILM NUMBER:		20606856
+
+	BUSINESS ADDRESS:	
+		STREET 1:		26 SE'ADYA GA'ON
+		CITY:			TEL AVIV - YAFFO
+		STATE:			L3
+		ZIP:			67135
+		BUSINESS PHONE:		972-3-5190640
+
+	MAIL ADDRESS:	
+		STREET 1:		26 SE'ADYA GA'ON
+		CITY:			TEL AVIV - YAFFO
+		STATE:			L3
+		ZIP:			67135
+</SEC-HEADER>
+<DOCUMENT>
+<TYPE>13F-NT
+<SEQUENCE>1
+<FILENAME>primary_doc.xml
+<TEXT>
+<XML>
+<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xsi:schemaLocation="http://www.sec.gov/edgar/thirteenffiler eis_13F_Filer.xsd" xmlns="http://www.sec.gov/edgar/thirteenffiler" xmlns:ns1="http://www.sec.gov/edgar/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <headerData>
+    <submissionType>13F-NT</submissionType>
+    <filerInfo>
+      <liveTestFlag>LIVE</liveTestFlag>
+      <flags>
+        <confirmingCopyFlag>false</confirmingCopyFlag>
+        <returnCopyFlag>false</returnCopyFlag>
+        <overrideInternetFlag>false</overrideInternetFlag>
+      </flags>
+      <filer>
+        <credentials>
+          <cik>0001727574</cik>
+          <ccc>XXXXXXXX</ccc>
+        </credentials>
+      </filer>
+      <periodOfReport>12-31-2019</periodOfReport>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPage>
+      <reportCalendarOrQuarter>12-31-2019</reportCalendarOrQuarter>
+      <isAmendment>false</isAmendment>
+      <filingManager>
+        <name>Migdal Investment Portfolio Management (1998) Ltd.</name>
+        <address>
+          <ns1:street1>26 Se'adya Ga'on</ns1:street1>
+          <ns1:city>Tel Aviv - Yaffo</ns1:city>
+          <ns1:stateOrCountry>L3</ns1:stateOrCountry>
+          <ns1:zipCode>67135</ns1:zipCode>
+        </address>
+      </filingManager>
+      <reportType>13F NOTICE</reportType>
+      <form13FFileNumber>028-18263</form13FFileNumber>
+      <otherManagersInfo>
+        <otherManager>
+          <cik>0001415912</cik>
+          <form13FFileNumber>028-17312</form13FFileNumber>
+          <name>Migdal Insurance &amp; Financial Holdings Ltd.</name>
+        </otherManager>
+      </otherManagersInfo>
+      <provideInfoForInstruction5>N</provideInfoForInstruction5>
+    </coverPage>
+    <signatureBlock>
+      <name>Peleg Tzur</name>
+      <title>CEO</title>
+      <phone>972-3-5190640</phone>
+      <signature>/s/ Peleg Tzur</signature>
+      <city>Tel Aviv - Yaffo</city>
+      <stateOrCountry>L3</stateOrCountry>
+      <signatureDate>02-09-2020</signatureDate>
+    </signatureBlock>
+    <summaryPage>
+      <otherIncludedManagersCount/>
+      <tableEntryTotal/>
+      <tableValueTotal/>
+    </summaryPage>
+  </formData>
+</edgarSubmission>
+</XML>
+</TEXT>
+</DOCUMENT>
+</SEC-DOCUMENT>


### PR DESCRIPTION
## Summary

Some filings have multiple single quotes in their header data.

Examples:
"https://www.sec.gov/Archives/edgar/data/1727574/000117891320000417/0001178913-20-000417.txt"
"https://www.sec.gov/Archives/edgar/data/1728584/000117891320000419/0001178913-20-000419.txt"

The existing logic was removing the first found single quote, but multiple were causing crashes in the yaml parser.

Test case added